### PR TITLE
Process recursive inclusions in hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### 0.4.0 (Unreleased)
+
+- Breaking changes
+  - Recursive inclusions now respect the hierarchy of configuration files, avoiding inclusions lower
+    in the hiearchy to be resolved before ones higher in the hierarchy
+    ([#14](https://github.com/velocidi/frise/pull/14)).
+
 ### 0.3.0 (April 16, 2018)
 
 - Breaking changes

--- a/lib/frise/loader.rb
+++ b/lib/frise/loader.rb
@@ -74,7 +74,7 @@ module Frise
           symbol_table = build_symbol_table(root_config, at_path, config, global_vars, include_conf)
           included_config = Parser.parse(include_conf['file'], symbol_table)
           config = @defaults_loader.merge_defaults_obj(config, included_config)
-          config = process_includes(config, at_path, merge_at(root_config, at_path, config), global_vars, rest_include_confs)
+          process_includes(config, at_path, merge_at(root_config, at_path, config), global_vars, rest_include_confs)
         end
       end
     end

--- a/lib/frise/loader.rb
+++ b/lib/frise/loader.rb
@@ -46,7 +46,7 @@ module Frise
 
     private
 
-    def process_includes(config, at_path, root_config, global_vars)
+    def process_includes(config, at_path, root_config, global_vars, include_confs_stack = [])
       return config unless config.class == Hash
 
       # process $content_include directives
@@ -63,20 +63,18 @@ module Frise
       end
 
       # process $include directives
-      config, include_confs = extract_include(config, at_path)
+      config, next_include_confs = extract_include(config, at_path)
+      include_confs = next_include_confs + include_confs_stack
       if include_confs.empty?
         config.map { |k, v| [k, process_includes(v, at_path + [k], root_config, global_vars)] }.to_h
       else
         Lazy.new do
-          include_confs.each do |include_conf|
-            symbol_table = build_symbol_table(root_config, at_path, config, global_vars, include_conf)
-            included_config = Parser.parse(include_conf['file'], symbol_table)
-
-            config = @defaults_loader.merge_defaults_obj(config, included_config)
-            config = process_includes(config, at_path, merge_at(root_config, at_path, config), global_vars)
-          end
-          updated_root_config = merge_at(root_config, at_path, config)
-          config.map { |k, v| [k, process_includes(v, at_path + [k], updated_root_config, global_vars)] }.to_h
+          include_conf = include_confs.first
+          rest_include_confs = include_confs[1..-1]
+          symbol_table = build_symbol_table(root_config, at_path, config, global_vars, include_conf)
+          included_config = Parser.parse(include_conf['file'], symbol_table)
+          config = @defaults_loader.merge_defaults_obj(config, included_config)
+          config = process_includes(config, at_path, merge_at(root_config, at_path, config), global_vars, rest_include_confs)
         end
       end
     end

--- a/lib/frise/version.rb
+++ b/lib/frise/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Frise
-  VERSION = '0.3.1.pre'
+  VERSION = '0.4.0.pre'
 end

--- a/spec/fixtures/loader_test11.yml
+++ b/spec/fixtures/loader_test11.yml
@@ -1,0 +1,6 @@
+$include:
+  - "{{ _file_dir }}/loader_test11_include1.yml"
+
+foo:
+  bar:
+    $include: ["{{ _file_dir }}/loader_test11_include2.yml"]

--- a/spec/fixtures/loader_test11_include1.yml
+++ b/spec/fixtures/loader_test11_include1.yml
@@ -1,0 +1,3 @@
+$include:
+  - "{{ _file_dir }}/loader_test11_include3.yml"
+  - "{{ _file_dir }}/loader_test11_include4.yml"

--- a/spec/fixtures/loader_test11_include2.yml
+++ b/spec/fixtures/loader_test11_include2.yml
@@ -1,0 +1,2 @@
+var1:
+  var2: '{{ foo.bar.baz }}'

--- a/spec/fixtures/loader_test11_include3.yml
+++ b/spec/fixtures/loader_test11_include3.yml
@@ -1,0 +1,3 @@
+foo:
+  bar:
+    other: "Something"

--- a/spec/fixtures/loader_test11_include4.yml
+++ b/spec/fixtures/loader_test11_include4.yml
@@ -1,0 +1,3 @@
+foo:
+  bar:
+    baz: "Hello World"

--- a/spec/frise/loader_spec.rb
+++ b/spec/frise/loader_spec.rb
@@ -232,4 +232,13 @@ RSpec.describe Loader do
     loader = Loader.new(exit_on_fail: false)
     expect(loader.load('non_existing_path.yml')).to eq(nil)
   end
+
+  it 'should allow referencing variables included in other files higher up in the configuration tree' do
+    loader = Loader.new(exit_on_fail: false)
+    conf = loader.load(fixture_path('loader_test11.yml'))
+
+    expect(conf).to eq('foo' => {'bar' => {'other' => 'Something',
+                                           'baz' => 'Hello World',
+                                           'var1' => {'var2' => 'Hello World'}}})
+  end
 end

--- a/spec/frise/loader_spec.rb
+++ b/spec/frise/loader_spec.rb
@@ -237,8 +237,16 @@ RSpec.describe Loader do
     loader = Loader.new(exit_on_fail: false)
     conf = loader.load(fixture_path('loader_test11.yml'))
 
-    expect(conf).to eq('foo' => {'bar' => {'other' => 'Something',
-                                           'baz' => 'Hello World',
-                                           'var1' => {'var2' => 'Hello World'}}})
+    expect(conf).to eq(
+      'foo' => {
+        'bar' => {
+          'other' => 'Something',
+          'baz' => 'Hello World',
+          'var1' => {
+            'var2' => 'Hello World'
+          }
+        }
+      }
+    )
   end
 end


### PR DESCRIPTION
This PR modifies the way a DFS for recursive inclusions in config files is performed so that the hierarchy of the configuration file is respected. For example, this means that in the following file:

```yaml
$include:
  - "include1.yml"
  - "include2.yml"

foo:
  $include: ["include3.yml"]
```

The order of visiting includes will be `include1.yml`, `include2.yml` and `include3.yml`, whereas before it would be `include1.yml`, `include3.yml` and `include2.yml`.