### PR TITLE
Fix error messages from validations happening deeper in the config hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 0.4.0 (Unreleased)
+
+- Bug fixes
+  - Fix error messages from validations happening deeper in the config hierarchy, that were wrongly
+    missing the first character in their path ([#16](https://github.com/velocidi/frise/pull/16)).
+
 ### 0.3.0 (April 16, 2018)
 
 - Breaking changes

--- a/lib/frise/validator.rb
+++ b/lib/frise/validator.rb
@@ -27,7 +27,7 @@ module Frise
     end
 
     def add_validation_error(path, msg)
-      logged_path = path.empty? ? '<root>' : path[1..-1]
+      logged_path = path.empty? ? '<root>' : path
       @errors << "At #{logged_path}: #{msg}"
     end
 
@@ -115,7 +115,7 @@ module Frise
     def validate_spec_keys(full_schema, obj, path, processed_keys)
       full_schema.each do |spec_key, spec_value|
         next if spec_key.is_a?(Symbol)
-        validate_object("#{path}.#{spec_key}", obj[spec_key], spec_value)
+        validate_object(path.empty? ? spec_key : "#{path}.#{spec_key}", obj[spec_key], spec_value)
         processed_keys << spec_key
       end
       true
@@ -132,7 +132,7 @@ module Frise
 
           next if processed_keys.member? key
           if full_schema[:all]
-            validate_object("#{path}.#{key}", value, full_schema[:all])
+            validate_object(path.empty? ? key : "#{path}.#{key}", value, full_schema[:all])
           elsif !full_schema[:allow_unknown_keys]
             add_validation_error(path, "unknown key: #{key}")
           end

--- a/spec/fixtures/_schemas/loader_test12.yml
+++ b/spec/fixtures/_schemas/loader_test12.yml
@@ -1,0 +1,3 @@
+$allow_unknown_keys: true
+value1: String
+value2: Int

--- a/spec/fixtures/loader_test12.yml
+++ b/spec/fixtures/loader_test12.yml
@@ -1,0 +1,3 @@
+variable1:
+  $schema: ["{{ _file_dir }}/_schemas/loader_test12.yml"]
+  value1: "Hello"

--- a/spec/frise/loader_spec.rb
+++ b/spec/frise/loader_spec.rb
@@ -232,4 +232,12 @@ RSpec.describe Loader do
     loader = Loader.new(exit_on_fail: false)
     expect(loader.load('non_existing_path.yml')).to eq(nil)
   end
+
+  it 'should validate schemas included deeper in the config file hierarchy' do
+    loader = Loader.new(exit_on_fail: true)
+    expect { loader.load(fixture_path('loader_test12.yml')) }.to output(
+      "1 config error(s) found:\n" \
+      " - At variable1.value2: missing required value\n"
+    ).to_stdout.and raise_error(SystemExit)
+  end
 end


### PR DESCRIPTION
This PR fixes the error messages from validations happening deeper in the config hierarchy, by not including a `.` prefix when joining two paths if the leftmost path is empty.