### PR TITLE
Fix deprecation warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,6 @@ rvm:
   - 2.4
   - 2.5
   - 2.6
+  - 2.7
 before_install:
   - gem install bundler

--- a/lib/frise/validator.rb
+++ b/lib/frise/validator.rb
@@ -163,7 +163,7 @@ module Frise
     end
 
     def self.validate_obj(config, schema, options = {})
-      validate_obj_at(config, [], schema, options)
+      validate_obj_at(config, [], schema, **options)
     end
 
     def self.validate_obj_at(config, at_path, schema, path_prefix: nil, validators: nil, print: nil, fatal: nil, raise_error: nil)
@@ -188,11 +188,11 @@ module Frise
     end
 
     def self.validate(config, schema_file, options = {})
-      validate_obj_at(config, [], Parser.parse(schema_file) || { allow_unknown_keys: true }, options)
+      validate_obj_at(config, [], Parser.parse(schema_file) || { allow_unknown_keys: true }, **options)
     end
 
     def self.validate_at(config, at_path, schema_file, options = {})
-      validate_obj_at(config, at_path, Parser.parse(schema_file) || { allow_unknown_keys: true }, options)
+      validate_obj_at(config, at_path, Parser.parse(schema_file) || { allow_unknown_keys: true }, **options)
     end
   end
 


### PR DESCRIPTION
We are getting a deprecation warning when calling the validator:

```
/usr/local/lib/ruby/gems/2.7.0/gems/frise-0.4.0/lib/frise/validator.rb:166: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/usr/local/lib/ruby/gems/2.7.0/gems/frise-0.4.0/lib/frise/validator.rb:169: warning: The called method `validate_obj_at' is defined here
```

This fixes it. I've run the tests before, verified the error was printed, and run them after and confirmed it was gone. 