### PR TITLE
Add delete directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 0.4.1 (tbd)
+
+- New features
+  - `$delete` directive is now available in config files, allowing users to delete parts of the
+    config sub-tree ([#20](https://github.com/velocidi/frise/pull/20)).
+
 ### 0.4.0 (November 29, 2019)
 
 - Breaking changes

--- a/lib/frise/defaults_loader.rb
+++ b/lib/frise/defaults_loader.rb
@@ -10,10 +10,11 @@ module Frise
   class DefaultsLoader
     SYMBOLS = %w[$all $optional].freeze
 
-    def initialize(include_sym: '$include', content_include_sym: '$content_include', schema_sym: '$schema')
+    def initialize(include_sym: '$include', content_include_sym: '$content_include', schema_sym: '$schema', delete_sym: '$delete')
       @include_sym = include_sym
       @content_include_sym = content_include_sym
       @schema_sym = schema_sym
+      @delete_sym = delete_sym
     end
 
     def widened_class(obj)
@@ -36,6 +37,9 @@ module Frise
         elsif defaults['$optional'] then nil
         else merge_defaults_obj({}, defaults)
         end
+
+      elsif config == @delete_sym
+        config
 
       elsif defaults_class == 'Array' && config_class == 'Array'
         defaults + config

--- a/lib/frise/loader.rb
+++ b/lib/frise/loader.rb
@@ -42,8 +42,8 @@ module Frise
         config = pre_loader.call(config)
       end
 
-      config = process_includes(config, [], config, global_vars) if @include_sym
-      config = process_schemas(config, [], global_vars) if @schema_sym
+      config = process_includes(config, [], config, global_vars) unless @include_sym.nil?
+      config = process_schemas(config, [], global_vars) unless @schema_sym.nil?
       config
     end
 
@@ -80,7 +80,7 @@ module Frise
                 process_includes(config, at_path, merge_at(root_config, at_path, config), global_vars, rest_include_confs)
               end
             end
-      omit_deleted(res)
+      @delete_sym.nil? ? res : omit_deleted(res)
     end
 
     def process_schema_includes(schema, at_path, global_vars)

--- a/lib/frise/loader.rb
+++ b/lib/frise/loader.rb
@@ -13,6 +13,7 @@ module Frise
     def initialize(include_sym: '$include',
                    content_include_sym: '$content_include',
                    schema_sym: '$schema',
+                   delete_sym: '$delete',
                    pre_loaders: [],
                    validators: nil,
                    exit_on_fail: true)
@@ -20,6 +21,7 @@ module Frise
       @include_sym = include_sym
       @content_include_sym = content_include_sym
       @schema_sym = schema_sym
+      @delete_sym = delete_sym
       @pre_loaders = pre_loaders
       @validators = validators
       @exit_on_fail = exit_on_fail
@@ -27,7 +29,8 @@ module Frise
       @defaults_loader = DefaultsLoader.new(
         include_sym: include_sym,
         content_include_sym: content_include_sym,
-        schema_sym: schema_sym
+        schema_sym: schema_sym,
+        delete_sym: delete_sym
       )
     end
 
@@ -40,6 +43,7 @@ module Frise
       end
 
       config = process_includes(config, [], config, global_vars) if @include_sym
+      config = omit_deleted(config)
       config = process_schemas(config, [], global_vars) if @schema_sym
       config
     end
@@ -160,6 +164,17 @@ module Frise
       config.merge(head => merge_at(config[head], tail, to_merge))
     end
 
+    # returns the config without the keys whose values are @delete_sym
+    def omit_deleted(config)
+      config.each_with_object({}) do |(k, v), new_hash|
+        if v.is_a?(Hash)
+          new_hash[k] = omit_deleted(v)
+        else
+          new_hash[k] = v unless v == @delete_sym
+        end
+      end
+    end
+
     # builds the symbol table for the Liquid renderization of a file, based on:
     #   - `root_config`: the root of the whole config
     #   - `at_path`: the current path
@@ -170,7 +185,7 @@ module Frise
       extra_vars = (include_conf['vars'] || {}).map { |k, v| [k, root_config.dig(*v.split('.'))] }.to_h
       extra_consts = include_conf['constants'] || {}
 
-      (config ? merge_at(root_config, at_path, config) : root_config)
+      omit_deleted(config ? merge_at(root_config, at_path, config) : root_config)
         .merge(global_vars)
         .merge(extra_vars)
         .merge(extra_consts)

--- a/spec/fixtures/_defaults/loader_test13.yml
+++ b/spec/fixtures/_defaults/loader_test13.yml
@@ -1,2 +1,3 @@
 bar: "str3"
 baz: "str4"
+other: "str5"

--- a/spec/fixtures/_defaults/loader_test13.yml
+++ b/spec/fixtures/_defaults/loader_test13.yml
@@ -1,0 +1,2 @@
+bar: "str3"
+baz: "str4"

--- a/spec/fixtures/_defaults/loader_test2.yml
+++ b/spec/fixtures/_defaults/loader_test2.yml
@@ -7,3 +7,5 @@ description: "Description of {{ name }} ({{ _extra.a }})"
 {% else %}
 description: "Description of {{ name }}"
 {% endif %}
+
+other: "plain"

--- a/spec/fixtures/_schemas/loader_test2.yml
+++ b/spec/fixtures/_schemas/loader_test2.yml
@@ -1,3 +1,4 @@
 id: String
 name: String
 description: String
+other: String?

--- a/spec/fixtures/loader_test13.yml
+++ b/spec/fixtures/loader_test13.yml
@@ -3,3 +3,4 @@ $include:
 
 foo: $delete
 bar: "str"
+other: $delete

--- a/spec/fixtures/loader_test13.yml
+++ b/spec/fixtures/loader_test13.yml
@@ -1,0 +1,5 @@
+$include:
+  - "{{ _file_dir }}/loader_test13_include.yml"
+
+foo: $delete
+bar: "str"

--- a/spec/fixtures/loader_test13_include.yml
+++ b/spec/fixtures/loader_test13_include.yml
@@ -4,3 +4,4 @@ $include:
 foo: "str2"
 bar: $delete
 baz: $delete
+liquid: {% if foo %}true{% endif %}

--- a/spec/fixtures/loader_test13_include.yml
+++ b/spec/fixtures/loader_test13_include.yml
@@ -1,0 +1,6 @@
+$include:
+  - "{{ _file_dir }}/defaults/loader_test13.yml"
+
+foo: "str2"
+bar: $delete
+baz: $delete

--- a/spec/fixtures/loader_test2_all_alt.yml
+++ b/spec/fixtures/loader_test2_all_alt.yml
@@ -2,3 +2,4 @@ __custom_sch: ["{{ _file_dir }}/_schemas/loader_test2.yml"]
 __custom_inc: ["{{ _file_dir }}/_defaults/loader_test2.yml"]
 
 name: "My Object"
+other: __custom_del

--- a/spec/frise/defaults_loader_spec.rb
+++ b/spec/frise/defaults_loader_spec.rb
@@ -112,4 +112,24 @@ RSpec.describe DefaultsLoader do
       .to raise_error 'Cannot merge config {"$content_include"=>["str.txt"]} (String) ' \
           'with default {"str"=>"abc", "int"=>4, "bool"=>true} (Hash)'
   end
+
+  it 'should override defaults when value is $delete' do
+    conf = {
+      'str' => '$delete',
+      'int' => '$delete',
+      'bool' => '$delete',
+      'arr' => '$delete',
+      'obj' => { 'key1' => '$delete', 'key3' => '$delete' }
+    }
+    conf = DefaultsLoader.new.merge_defaults(conf, fixture_path('all_types.yml'))
+    expect(conf['str']).to eq '$delete'
+    expect(conf['int']).to eq '$delete'
+    expect(conf['bool']).to eq '$delete'
+    expect(conf['arr']).to eq '$delete'
+    expect(conf['obj']).to eq(
+      'key1' => '$delete',
+      'key2' => 'value2',
+      'key3' => '$delete'
+    )
+  end
 end

--- a/spec/frise/loader_spec.rb
+++ b/spec/frise/loader_spec.rb
@@ -72,12 +72,16 @@ RSpec.describe Loader do
     expect(conf).to eq(
       'id' => 'myobj',
       'name' => 'My Object',
-      'description' => 'Description of My Object (42)'
+      'description' => 'Description of My Object (42)',
+      'other' => 'plain'
     )
   end
 
-  it 'should allow using a different key or no key for inclusions and schemas' do
-    loader = Loader.new(include_sym: '__custom_inc', schema_sym: '__custom_sch', exit_on_fail: false)
+  it 'should allow using a different key or no key for inclusions/schemas/deletes' do
+    loader = Loader.new(include_sym: '__custom_inc',
+                        schema_sym: '__custom_sch',
+                        delete_sym: '__custom_del',
+                        exit_on_fail: false)
 
     conf = loader.load(fixture_path('loader_test2_all_alt.yml'), '_id' => 'myobj')
     expect(conf).to eq(
@@ -158,7 +162,8 @@ RSpec.describe Loader do
     expect(conf).to eq(
       'id' => 'myobj',
       'name' => 'My Object',
-      'description' => 'Description of My Object'
+      'description' => 'Description of My Object',
+      'other' => 'plain'
     )
 
     conf = loader.load(fixture_path('loader_test2_templated.yml'), '_with_schema' => true)
@@ -171,7 +176,8 @@ RSpec.describe Loader do
     expect(conf).to eq(
       'id' => 'myobj',
       'name' => 'My Object',
-      'description' => 'Description of My Object'
+      'description' => 'Description of My Object',
+      'other' => 'plain'
     )
   end
 
@@ -256,5 +262,14 @@ RSpec.describe Loader do
       "1 config error(s) found:\n" \
       " - At variable1.value2: missing required value\n"
     ).to_stdout.and raise_error(SystemExit)
+  end
+
+  it 'should delete sub-tree when value is $delete' do
+    loader = Loader.new(exit_on_fail: false)
+
+    conf = loader.load(fixture_path('loader_test13.yml'))
+    expect(conf).to eq(
+      'bar' => 'str'
+    )
   end
 end


### PR DESCRIPTION
Introduces a `$delete` directive which allows deleting a config sub-tree.
This proves useful for situations when there is a exception to the defaults where we need to remove one key.