### PR TITLE
Increase minimum required ruby version to 2.6.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ 2.5, 2.6, 2.7 ]
+        ruby: [ 2.6, 2.7, 3.0 ]
 
     steps:
       - uses: actions/checkout@v2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: '2.3'
+  NewCops: enable
 Layout/EmptyLineAfterGuardClause:
   Enabled: false
 Metrics:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 0.5.0 (TBD)
+
+- Breaking changes
+  - Increase minimum required ruby version to 2.6.0 ([]()).
+
 ### 0.4.1 (July 7, 2020)
 
 - New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### 0.5.0 (TBD)
 
 - Breaking changes
-  - Increase minimum required ruby version to 2.6.0 ([]()).
+  - Increase minimum required ruby version to 2.6.0 ([#22](https://github.com/velocidi/frise/pull/22)).
 
 ### 0.4.1 (July 7, 2020)
 

--- a/frise.gemspec
+++ b/frise.gemspec
@@ -18,14 +18,14 @@ Gem::Specification.new do |spec|
     f.match(%r{^(test|spec|features|example)/})
   end
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.3.0'
+  spec.required_ruby_version = '>= 2.6.0'
 
   spec.add_dependency 'liquid', '~> 4.0'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.9'
-  spec.add_development_dependency 'rubocop', '0.77.0'
+  spec.add_development_dependency 'rubocop', '~> 1.10'
   spec.add_development_dependency 'simplecov', '~> 0.18'
   spec.add_development_dependency 'simplecov-lcov', '0.8.0'
 end

--- a/lib/frise/defaults_loader.rb
+++ b/lib/frise/defaults_loader.rb
@@ -10,7 +10,13 @@ module Frise
   class DefaultsLoader
     SYMBOLS = %w[$all $optional].freeze
 
-    def initialize(include_sym: '$include', content_include_sym: '$content_include', schema_sym: '$schema', delete_sym: '$delete')
+    def initialize(
+      include_sym: '$include',
+      content_include_sym: '$content_include',
+      schema_sym: '$schema',
+      delete_sym: '$delete'
+    )
+
       @include_sym = include_sym
       @content_include_sym = content_include_sym
       @schema_sym = schema_sym
@@ -25,6 +31,7 @@ module Frise
       class_name
     end
 
+    # rubocop:disable Lint/DuplicateBranch
     def merge_defaults_obj(config, defaults)
       config_class = widened_class(config)
       defaults_class = widened_class(defaults)
@@ -66,6 +73,7 @@ module Frise
         config
       end
     end
+    # rubocop:enable Lint/DuplicateBranch
 
     def merge_defaults_obj_at(config, at_path, defaults)
       at_path.reverse.each { |key| defaults = { key => defaults } }

--- a/lib/frise/loader/lazy.rb
+++ b/lib/frise/loader/lazy.rb
@@ -12,11 +12,9 @@ module Frise
         @__target_object__ ||= @callable.call
       end
 
-      # rubocop:disable Style/MethodMissingSuper
       def method_missing(method_name, *args, &block)
         __target_object__.send(method_name, *args, &block)
       end
-      # rubocop:enable Style/MethodMissingSuper
 
       def respond_to_missing?(method_name, include_private = false)
         __target_object__.respond_to?(method_name, include_private)

--- a/lib/frise/validator.rb
+++ b/lib/frise/validator.rb
@@ -14,6 +14,8 @@ module Frise
     attr_reader :errors
 
     def initialize(root, validators = nil)
+      super()
+
       @root = root
       @validators = validators
       @errors = []
@@ -33,7 +35,7 @@ module Frise
 
     def get_full_schema(schema)
       case schema
-      when Hash then
+      when Hash
         default_type = schema[:enum] || schema[:one_of] ? 'Object' : 'Hash'
         { type: default_type }.merge(schema)
       when Symbol then { type: 'Object', validate: schema }
@@ -124,7 +126,7 @@ module Frise
     def validate_remaining_keys(full_schema, obj, path, processed_keys)
       expected_types = get_expected_types(full_schema)
       if expected_types.size == 1 && expected_types[0].ancestors.member?(Enumerable)
-        hash = obj.is_a?(Hash) ? obj : Hash[obj.map.with_index { |x, i| [i, x] }]
+        hash = obj.is_a?(Hash) ? obj : obj.map.with_index { |x, i| [i, x] }.to_h
         hash.each do |key, value|
           validate_object(path, key, full_schema[:all_keys]) if full_schema[:all_keys] && !key.is_a?(Symbol)
 
@@ -156,8 +158,8 @@ module Frise
     def self.parse_symbols(obj)
       case obj
       when Array then obj.map { |e| parse_symbols(e) }
-      when Hash then Hash[obj.map { |k, v| [parse_symbols(k), parse_symbols(v)] }]
-      when String then obj.start_with?('$') ? obj[1..-1].to_sym : obj
+      when Hash then obj.map { |k, v| [parse_symbols(k), parse_symbols(v)] }.to_h
+      when String then obj.start_with?('$') ? obj[1..].to_sym : obj
       else obj
       end
     end
@@ -166,7 +168,17 @@ module Frise
       validate_obj_at(config, [], schema, **options)
     end
 
-    def self.validate_obj_at(config, at_path, schema, path_prefix: nil, validators: nil, print: nil, fatal: nil, raise_error: nil)
+    def self.validate_obj_at(
+      config,
+      at_path,
+      schema,
+      path_prefix: nil,
+      validators: nil,
+      print: nil,
+      fatal: nil,
+      raise_error: nil
+    )
+
       schema = parse_symbols(schema)
       at_path.reverse.each { |key| schema = { key => schema, :allow_unknown_keys => true } }
 
@@ -202,6 +214,8 @@ module Frise
     attr_reader :errors
 
     def initialize(errors)
+      super()
+
       @errors = errors
     end
   end

--- a/lib/frise/version.rb
+++ b/lib/frise/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Frise
-  VERSION = '0.4.2.pre'
+  VERSION = '0.5.0.pre'
 end


### PR DESCRIPTION
Increases minimum required ruby version to 2.6.0, bumps rubocop and applies rubocop suggestions.