### PR TITLE
Correct loader spec example for $delete keyword

### DIFF
--- a/spec/fixtures/_defaults/loader_test13.yml
+++ b/spec/fixtures/_defaults/loader_test13.yml
@@ -1,3 +1,4 @@
 bar: "str3"
 baz: "str4"
 other: "str5"
+kept_from_default: "str"

--- a/spec/fixtures/loader_test13_include.yml
+++ b/spec/fixtures/loader_test13_include.yml
@@ -1,5 +1,5 @@
 $include:
-  - "{{ _file_dir }}/defaults/loader_test13.yml"
+  - "{{ _file_dir }}/_defaults/loader_test13.yml"
 
 foo: "str2"
 bar: $delete

--- a/spec/frise/loader_spec.rb
+++ b/spec/frise/loader_spec.rb
@@ -270,7 +270,7 @@ RSpec.describe Loader do
     conf = loader.load(fixture_path('loader_test13.yml'))
     expect(conf).to eq(
       'bar' => 'str',
-      'kept_from_default' => "str"
+      'kept_from_default' => 'str'
     )
   end
 end

--- a/spec/frise/loader_spec.rb
+++ b/spec/frise/loader_spec.rb
@@ -269,7 +269,8 @@ RSpec.describe Loader do
 
     conf = loader.load(fixture_path('loader_test13.yml'))
     expect(conf).to eq(
-      'bar' => 'str'
+      'bar' => 'str',
+      'kept_from_default' => "str"
     )
   end
 end


### PR DESCRIPTION
Correct loader spec example for $delete keyword. It had an incorrect file path definition.