### PR TITLE
Allow deleting subtree across multiple merges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 - Breaking changes
   - Increase minimum required ruby version to 2.6.0 ([#22](https://github.com/velocidi/frise/pull/22)).
+- Bug fixes
+  - Fix `$delete` directive behavior, allowing it to work across any number of configuration tree levels 
+    ([#24](https://github.com/velocidi/frise/pull/24)).
 
 ### 0.4.1 (July 7, 2020)
 

--- a/lib/frise/defaults_loader.rb
+++ b/lib/frise/defaults_loader.rb
@@ -23,30 +23,6 @@ module Frise
       @delete_sym = delete_sym
     end
 
-    # returns the config without the keys whose values are marked for removal
-    def clear_delete_markers(config)
-      case config
-      when Hash
-        config.each_with_object({}) do |(k, v), new_hash|
-          if v.instance_of?(Frise::DefaultsLoader::DeleteMarker)
-            new_hash[k] = v.value unless v.value.nil?
-          elsif v != @delete_sym
-            new_hash[k] = clear_delete_markers(v)
-          end
-        end
-      when Array
-        config.each_with_object([]) do |elem, new_arr|
-          if elem.instance_of?(Frise::DefaultsLoader::DeleteMarker)
-            new_arr.push(elem.value) unless elem.value.nil?
-          elsif elem != @delete_sym
-            new_arr.push(clear_delete_markers(elem))
-          end
-        end
-      else
-        config
-      end
-    end
-
     # rubocop:disable Lint/DuplicateBranch
     def merge_defaults_obj(config, defaults)
       config_class = widened_class(config)
@@ -61,8 +37,8 @@ module Frise
         else merge_defaults_obj({}, defaults)
         end
 
-      elsif delete_marker?(config) || delete_marker?(defaults)
-        DeleteMarker.new(@delete_sym, config)
+      elsif config == @delete_sym || defaults == @delete_sym
+        config
 
       elsif defaults_class == 'Array' && config_class == 'Array'
         defaults + config
@@ -114,35 +90,6 @@ module Frise
       return 'Boolean' if %w[TrueClass FalseClass].include? class_name
       return 'Integer' if %w[Fixnum Bignum].include? class_name
       class_name
-    end
-
-    def delete_marker?(conf)
-      conf == @delete_sym || conf.instance_of?(Frise::DefaultsLoader::DeleteMarker)
-    end
-
-    # Keeps state once a delete symbol is found, so that we can keep deleting to the "right" while merging values.
-    class DeleteMarker
-      attr_accessor :value
-
-      def initialize(delete_sym, left)
-        @delete_sym = delete_sym
-
-        @value = if left == delete_sym
-                   nil
-                 elsif left.instance_of?(self.class)
-                   left.value
-                 else
-                   left
-                 end
-      end
-
-      def to_s
-        if @value.nil?
-          @delete_sym.to_s
-        else
-          @value.to_s
-        end
-      end
     end
   end
 end

--- a/lib/frise/loader.rb
+++ b/lib/frise/loader.rb
@@ -81,7 +81,7 @@ module Frise
                                  rest_include_confs)
               end
             end
-      @delete_sym.nil? ? res : omit_deleted(res)
+      @delete_sym.nil? ? res : @defaults_loader.clear_deleted_markers(res)
     end
 
     def process_schema_includes(schema, at_path, global_vars)
@@ -165,17 +165,6 @@ module Frise
       config.merge(head => merge_at(config[head], tail, to_merge))
     end
 
-    # returns the config without the keys whose values are @delete_sym
-    def omit_deleted(config)
-      config.each_with_object({}) do |(k, v), new_hash|
-        if v.is_a?(Hash)
-          new_hash[k] = omit_deleted(v)
-        else
-          new_hash[k] = v unless v == @delete_sym
-        end
-      end
-    end
-
     # builds the symbol table for the Liquid renderization of a file, based on:
     #   - `root_config`: the root of the whole config
     #   - `at_path`: the current path
@@ -186,7 +175,7 @@ module Frise
       extra_vars = (include_conf['vars'] || {}).transform_values { |v| root_config.dig(*v.split('.')) }
       extra_consts = include_conf['constants'] || {}
 
-      omit_deleted(config ? merge_at(root_config, at_path, config) : root_config)
+      @defaults_loader.clear_deleted_markers(config ? merge_at(root_config, at_path, config) : root_config)
         .merge(global_vars)
         .merge(extra_vars)
         .merge(extra_consts)

--- a/lib/frise/loader.rb
+++ b/lib/frise/loader.rb
@@ -81,7 +81,7 @@ module Frise
                                  rest_include_confs)
               end
             end
-      @delete_sym.nil? ? res : @defaults_loader.clear_deleted_markers(res)
+      @delete_sym.nil? ? res : @defaults_loader.clear_delete_markers(res)
     end
 
     def process_schema_includes(schema, at_path, global_vars)
@@ -175,11 +175,11 @@ module Frise
       extra_vars = (include_conf['vars'] || {}).transform_values { |v| root_config.dig(*v.split('.')) }
       extra_consts = include_conf['constants'] || {}
 
-      @defaults_loader.clear_deleted_markers(config ? merge_at(root_config, at_path, config) : root_config)
-        .merge(global_vars)
-        .merge(extra_vars)
-        .merge(extra_consts)
-        .merge('_this' => config)
+      @defaults_loader.clear_delete_markers(config ? merge_at(root_config, at_path, config) : root_config)
+                      .merge(global_vars)
+                      .merge(extra_vars)
+                      .merge(extra_consts)
+                      .merge('_this' => config)
     end
 
     # builds a user-friendly string indicating a path

--- a/spec/fixtures/_defaults/loader_test13.yml
+++ b/spec/fixtures/_defaults/loader_test13.yml
@@ -2,3 +2,5 @@ bar: "str3"
 baz: "str4"
 other: "str5"
 kept_from_default: "str"
+my_array:
+  - "incorrect"

--- a/spec/fixtures/all_types.yml
+++ b/spec/fixtures/all_types.yml
@@ -3,6 +3,7 @@ int: 3
 bool: true
 bool2: false
 arr: ["elem0", "elem1"]
+another_arr: ["elem0", "elem1"]
 obj:
   key1: "value1"
   key2: "value2"

--- a/spec/fixtures/loader_test13.yml
+++ b/spec/fixtures/loader_test13.yml
@@ -4,3 +4,5 @@ $include:
 foo: $delete
 bar: "str"
 other: $delete
+my_array:
+  - "correct"

--- a/spec/fixtures/loader_test13_include.yml
+++ b/spec/fixtures/loader_test13_include.yml
@@ -5,3 +5,4 @@ foo: "str2"
 bar: $delete
 baz: $delete
 liquid: {% if foo %}true{% endif %}
+my_array: $delete

--- a/spec/fixtures/loader_test14_1.yml
+++ b/spec/fixtures/loader_test14_1.yml
@@ -1,0 +1,4 @@
+$include:
+  - "{{ _file_dir }}/loader_test14_include_part1.yml"
+  - "{{ _file_dir }}/loader_test14_include_part2.yml"
+  - "{{ _file_dir }}/loader_test14_include_part3.yml"

--- a/spec/fixtures/loader_test14_2.yml
+++ b/spec/fixtures/loader_test14_2.yml
@@ -2,4 +2,3 @@ $include:
   - "{{ _file_dir }}/loader_test14_include_part3.yml"
   - "{{ _file_dir }}/loader_test14_include_part2.yml"
   - "{{ _file_dir }}/loader_test14_include_part1.yml"
-

--- a/spec/fixtures/loader_test14_2.yml
+++ b/spec/fixtures/loader_test14_2.yml
@@ -1,0 +1,5 @@
+$include:
+  - "{{ _file_dir }}/loader_test14_include_part3.yml"
+  - "{{ _file_dir }}/loader_test14_include_part2.yml"
+  - "{{ _file_dir }}/loader_test14_include_part1.yml"
+

--- a/spec/fixtures/loader_test14_include_part1.yml
+++ b/spec/fixtures/loader_test14_include_part1.yml
@@ -1,0 +1,8 @@
+my_obj:
+  obj1:
+    key11: 'key11'
+    key12: 'key12'
+  obj2:
+    key21: 'key21'
+    key22: 'key22'
+  obj3: $delete

--- a/spec/fixtures/loader_test14_include_part2.yml
+++ b/spec/fixtures/loader_test14_include_part2.yml
@@ -1,0 +1,6 @@
+my_obj:
+  obj1:
+    key13: 'key13'
+  obj2: $delete
+  obj3:
+    key31: 'key31'

--- a/spec/fixtures/loader_test14_include_part3.yml
+++ b/spec/fixtures/loader_test14_include_part3.yml
@@ -1,0 +1,6 @@
+my_obj:
+  obj1: $delete
+  obj2:
+    key23: 'key23'
+  obj3:
+    key32: 'key32'

--- a/spec/frise/defaults_loader_spec.rb
+++ b/spec/frise/defaults_loader_spec.rb
@@ -122,15 +122,16 @@ RSpec.describe DefaultsLoader do
       'another_arr' => ['$delete'], # has no effect inside an array
       'obj' => { 'key1' => '$delete', 'key3' => '$delete' }
     }
-    loader = DefaultsLoader.new
-    conf = loader.clear_delete_markers(loader.merge_defaults(conf, fixture_path('all_types.yml')))
-    expect(conf.key?('str')).to be false
-    expect(conf.key?('int')).to be false
-    expect(conf.key?('bool')).to be false
-    expect(conf.key?('arr')).to be false
-    expect(conf['another_arr']).to eq(%w[elem0 elem1])
+    conf = DefaultsLoader.new.merge_defaults(conf, fixture_path('all_types.yml'))
+    expect(conf['str']).to eq '$delete'
+    expect(conf['int']).to eq '$delete'
+    expect(conf['bool']).to eq '$delete'
+    expect(conf['arr']).to eq '$delete'
+    expect(conf['another_arr']).to eq(%w[elem0 elem1 $delete])
     expect(conf['obj']).to eq(
-      'key2' => 'value2'
+      'key1' => '$delete',
+      'key2' => 'value2',
+      'key3' => '$delete'
     )
   end
 end

--- a/spec/frise/defaults_loader_spec.rb
+++ b/spec/frise/defaults_loader_spec.rb
@@ -119,17 +119,18 @@ RSpec.describe DefaultsLoader do
       'int' => '$delete',
       'bool' => '$delete',
       'arr' => '$delete',
+      'another_arr' => ['$delete'], # has no effect inside an array
       'obj' => { 'key1' => '$delete', 'key3' => '$delete' }
     }
-    conf = DefaultsLoader.new.merge_defaults(conf, fixture_path('all_types.yml'))
-    expect(conf['str']).to eq '$delete'
-    expect(conf['int']).to eq '$delete'
-    expect(conf['bool']).to eq '$delete'
-    expect(conf['arr']).to eq '$delete'
+    loader = DefaultsLoader.new
+    conf = loader.clear_deleted_markers(loader.merge_defaults(conf, fixture_path('all_types.yml')))
+    expect(conf.key?('str')).to be false
+    expect(conf.key?('int')).to be false
+    expect(conf.key?('bool')).to be false
+    expect(conf.key?('arr')).to be false
+    expect(conf['another_arr']).to eq(["elem0", "elem1"])
     expect(conf['obj']).to eq(
-      'key1' => '$delete',
-      'key2' => 'value2',
-      'key3' => '$delete'
+      'key2' => 'value2'
     )
   end
 end

--- a/spec/frise/defaults_loader_spec.rb
+++ b/spec/frise/defaults_loader_spec.rb
@@ -123,12 +123,12 @@ RSpec.describe DefaultsLoader do
       'obj' => { 'key1' => '$delete', 'key3' => '$delete' }
     }
     loader = DefaultsLoader.new
-    conf = loader.clear_deleted_markers(loader.merge_defaults(conf, fixture_path('all_types.yml')))
+    conf = loader.clear_delete_markers(loader.merge_defaults(conf, fixture_path('all_types.yml')))
     expect(conf.key?('str')).to be false
     expect(conf.key?('int')).to be false
     expect(conf.key?('bool')).to be false
     expect(conf.key?('arr')).to be false
-    expect(conf['another_arr']).to eq(["elem0", "elem1"])
+    expect(conf['another_arr']).to eq(%w[elem0 elem1])
     expect(conf['obj']).to eq(
       'key2' => 'value2'
     )

--- a/spec/frise/loader_spec.rb
+++ b/spec/frise/loader_spec.rb
@@ -270,7 +270,7 @@ RSpec.describe Loader do
     conf = loader.load(fixture_path('loader_test13.yml'))
     expect(conf).to eq(
       'bar' => 'str',
-      'kept_from_default' => "str",
+      'kept_from_default' => 'str',
       'my_array' => ['correct']
     )
   end
@@ -279,15 +279,15 @@ RSpec.describe Loader do
     loader = Loader.new(exit_on_fail: false)
 
     conf = loader.load(fixture_path('loader_test14_1.yml'))
-    expect(conf).to eq({"my_obj" => {
-      "obj1"=>{"key11"=>"key11", "key12"=>"key12", "key13"=>"key13"},
-      "obj2"=>{"key21"=>"key21", "key22"=>"key22"}
-    }
-                       })
+    expect(conf).to eq({ 'my_obj' => {
+                         'obj1' => { 'key11' => 'key11', 'key12' => 'key12', 'key13' => 'key13' },
+                         'obj2' => { 'key21' => 'key21', 'key22' => 'key22' }
+                       } })
 
     conf = loader.load(fixture_path('loader_test14_2.yml'))
-    expect(conf).to eq({"my_obj" => {
-      "obj2"=>{"key23"=>"key23"},
-      "obj3"=>{"key31"=>"key31", "key32"=>"key32"}}})
+    expect(conf).to eq({ 'my_obj' => {
+                         'obj2' => { 'key23' => 'key23' },
+                         'obj3' => { 'key31' => 'key31', 'key32' => 'key32' }
+                       } })
   end
 end

--- a/spec/frise/loader_spec.rb
+++ b/spec/frise/loader_spec.rb
@@ -270,7 +270,24 @@ RSpec.describe Loader do
     conf = loader.load(fixture_path('loader_test13.yml'))
     expect(conf).to eq(
       'bar' => 'str',
-      'kept_from_default' => 'str'
+      'kept_from_default' => "str",
+      'my_array' => ['correct']
     )
+  end
+
+  it 'should provide consistent $delete results according to inclusion order' do
+    loader = Loader.new(exit_on_fail: false)
+
+    conf = loader.load(fixture_path('loader_test14_1.yml'))
+    expect(conf).to eq({"my_obj" => {
+      "obj1"=>{"key11"=>"key11", "key12"=>"key12", "key13"=>"key13"},
+      "obj2"=>{"key21"=>"key21", "key22"=>"key22"}
+    }
+                       })
+
+    conf = loader.load(fixture_path('loader_test14_2.yml'))
+    expect(conf).to eq({"my_obj" => {
+      "obj2"=>{"key23"=>"key23"},
+      "obj3"=>{"key31"=>"key31", "key32"=>"key32"}}})
   end
 end


### PR DESCRIPTION
The previous delete behavior was not accounting for merging of multiple levels and deleting objects that are found after the first delete. This tries to correct that by specifying that once we find a delete symbol, any next merge will also see the corresponding path deleted.