### PR TITLE
Fix symbol table when processing included files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Bug fixes
   - Fix `$delete` directive behavior, allowing it to work across any number of configuration tree levels 
     ([#24](https://github.com/velocidi/frise/pull/24)).
+  - Fix symbol table when processing included files ([#25](https://github.com/velocidi/frise/pull/25)).
 
 ### 0.4.1 (July 7, 2020)
 

--- a/spec/fixtures/_defaults/loader_test4_key2.yml
+++ b/spec/fixtures/_defaults/loader_test4_key2.yml
@@ -1,1 +1,2 @@
 value2_1: 10
+value2_2: "correct-{{ _this.value2_1 }}"

--- a/spec/fixtures/_defaults/loader_test4_key3.yml
+++ b/spec/fixtures/_defaults/loader_test4_key3.yml
@@ -1,0 +1,5 @@
+{% if _this.value1_1 == 1 %}
+value1_3: "correct"
+{% else %}
+value1_3: "incorrect"
+{% endif %}

--- a/spec/fixtures/_defaults/loader_test4_key4.yml
+++ b/spec/fixtures/_defaults/loader_test4_key4.yml
@@ -1,0 +1,1 @@
+value1_4: {{ _this.value1_1 }}

--- a/spec/fixtures/_schemas/loader_test4_key1.yml
+++ b/spec/fixtures/_schemas/loader_test4_key1.yml
@@ -1,4 +1,7 @@
 value1_1: Integer
 value1_2: String
+value1_3: String
+value1_4: Integer
 key2:
   value2_1: Integer
+  value2_2: String

--- a/spec/fixtures/_schemas/loader_test4_key2.yml
+++ b/spec/fixtures/_schemas/loader_test4_key2.yml
@@ -1,1 +1,2 @@
 value2_1: Integer
+value2_2: String

--- a/spec/fixtures/loader_test4.yml
+++ b/spec/fixtures/loader_test4.yml
@@ -1,7 +1,10 @@
 key1:
   value1_1: 1
   $schema: ["{{ _file_dir }}/_schemas/loader_test4_key1.yml"]
-  $include: ["{{ _file_dir }}/_defaults/loader_test4_key1.yml"]
+  $include:
+    - "{{ _file_dir }}/_defaults/loader_test4_key1.yml"
+    - "{{ _file_dir }}/_defaults/loader_test4_key3.yml"
+    - "{{ _file_dir }}/_defaults/loader_test4_key4.yml"
   key2:
     value2_1: 2
     $schema: ["{{ _file_dir }}/_schemas/loader_test4_key2.yml"]

--- a/spec/frise/loader_spec.rb
+++ b/spec/frise/loader_spec.rb
@@ -124,7 +124,9 @@ RSpec.describe Loader do
       'key1' => {
         'value1_1' => 1,
         'value1_2' => 'abc',
-        'key2' => { 'value2_1' => 2 }
+        'value1_3' => 'correct',
+        'value1_4' => 1,
+        'key2' => { 'value2_1' => 2, 'value2_2' => 'correct-2' }
       }
     )
   end


### PR DESCRIPTION
The symbol table was not being correctly generated when processing the included files, after #24. This corrects it and adds expands the specs to catch those situations.