### PR TITLE
Fix YAML safe_load call arguments

### DIFF
--- a/frise.gemspec
+++ b/frise.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 1.10'
   spec.add_development_dependency 'simplecov', '~> 0.18'
   spec.add_development_dependency 'simplecov-lcov', '0.8.0'
+  spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/lib/frise/defaults_loader.rb
+++ b/lib/frise/defaults_loader.rb
@@ -34,7 +34,8 @@ module Frise
       elsif config.nil?
         if defaults_class != 'Hash' then defaults
         elsif defaults['$optional'] then nil
-        else merge_defaults_obj({}, defaults)
+        else
+          merge_defaults_obj({}, defaults)
         end
 
       elsif config == @delete_sym || defaults == @delete_sym
@@ -59,7 +60,7 @@ module Frise
 
       elsif defaults_class != config_class
         raise "Cannot merge config #{config.inspect} (#{widened_class(config)}) " \
-          "with default #{defaults.inspect} (#{widened_class(defaults)})"
+              "with default #{defaults.inspect} (#{widened_class(defaults)})"
 
       else
         config

--- a/lib/frise/loader.rb
+++ b/lib/frise/loader.rb
@@ -69,7 +69,7 @@ module Frise
       config, next_include_confs = extract_include(config, at_path)
       include_confs = next_include_confs.map { |include| { _this: config, include: include } } + include_confs_stack
       res = if include_confs.empty?
-              config.map { |k, v| [k, process_includes(v, at_path + [k], root_config, global_vars)] }.to_h
+              config.to_h { |k, v| [k, process_includes(v, at_path + [k], root_config, global_vars)] }
             else
               Lazy.new do
                 include_conf = include_confs.first
@@ -92,7 +92,7 @@ module Frise
 
       schema, included_schemas = extract_include(schema, at_path)
       if included_schemas.empty?
-        schema.map { |k, v| [k, process_schema_includes(v, at_path + [k], global_vars)] }.to_h
+        schema.to_h { |k, v| [k, process_schema_includes(v, at_path + [k], global_vars)] }
       else
         included_schemas.each do |defaults_conf|
           schema = Parser.parse(defaults_conf['file'], global_vars).merge(schema)
@@ -104,11 +104,11 @@ module Frise
     def process_schemas(config, at_path, global_vars)
       return config unless config.instance_of?(Hash)
 
-      config = config.map do |k, v|
+      config = config.to_h do |k, v|
         new_v = process_schemas(v, at_path + [k], global_vars)
         return nil if !v.nil? && new_v.nil?
         [k, new_v]
-      end.to_h
+      end
 
       config, schema_files = extract_schema(config, at_path)
       schema_files.each do |schema_file|

--- a/lib/frise/parser.rb
+++ b/lib/frise/parser.rb
@@ -10,7 +10,7 @@ module Frise
     class << self
       def parse(file, symbol_table = nil)
         return nil unless File.file? file
-        YAML.safe_load(parse_as_text(file, symbol_table), [], [], true) || {}
+        YAML.safe_load(parse_as_text(file, symbol_table), aliases: true) || {}
       end
 
       def parse_as_text(file, symbol_table = nil)

--- a/lib/frise/validator.rb
+++ b/lib/frise/validator.rb
@@ -95,7 +95,7 @@ module Frise
     def validate_enum(full_schema, obj, path)
       if full_schema[:enum] && !full_schema[:enum].include?(obj)
         add_validation_error(path, "invalid value #{obj.inspect}. " \
-          "Accepted values are #{full_schema[:enum].map(&:inspect).join(', ')}")
+                                   "Accepted values are #{full_schema[:enum].map(&:inspect).join(', ')}")
         return false
       end
       true
@@ -158,7 +158,7 @@ module Frise
     def self.parse_symbols(obj)
       case obj
       when Array then obj.map { |e| parse_symbols(e) }
-      when Hash then obj.map { |k, v| [parse_symbols(k), parse_symbols(v)] }.to_h
+      when Hash then obj.to_h { |k, v| [parse_symbols(k), parse_symbols(v)] }
       when String then obj.start_with?('$') ? obj[1..].to_sym : obj
       else obj
       end

--- a/spec/frise/defaults_loader_spec.rb
+++ b/spec/frise/defaults_loader_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe DefaultsLoader do
     conf = { '$content_include' => ['str.txt'] }
     expect { DefaultsLoader.new.merge_defaults(conf, fixture_path('simple.yml')) }
       .to raise_error 'Cannot merge config {"$content_include"=>["str.txt"]} (String) ' \
-          'with default {"str"=>"abc", "int"=>4, "bool"=>true} (Hash)'
+                      'with default {"str"=>"abc", "int"=>4, "bool"=>true} (Hash)'
   end
 
   it 'should override defaults when value is $delete' do

--- a/spec/frise/loader_spec.rb
+++ b/spec/frise/loader_spec.rb
@@ -6,7 +6,7 @@ include Frise
 
 validators = Object.new
 def validators.short_string(_, str)
-  str.is_a?(String) && str.length < 5 || (raise "expected a short string, found #{str.inspect}")
+  (str.is_a?(String) && str.length < 5) || (raise "expected a short string, found #{str.inspect}")
 end
 
 RSpec.describe Loader do
@@ -42,7 +42,7 @@ RSpec.describe Loader do
   end
 
   it 'should allow providing actions to be run just before loading defaults and schemas' do
-    on_load = ->(conf) { conf.map { |k, v| ["prefix_#{k}", v] }.to_h }
+    on_load = ->(conf) { conf.transform_keys { |k| "prefix_#{k}" } }
 
     loader = Loader.new(pre_loaders: [on_load], exit_on_fail: false)
 

--- a/spec/frise/validator_spec.rb
+++ b/spec/frise/validator_spec.rb
@@ -112,11 +112,11 @@ RSpec.describe Validator do
   it 'should allow custom validations in schemas' do
     validators = Object.new
     def validators.even_int(_, n)
-      n.is_a?(Integer) && (n % 2).zero? || (raise "expected an even number, found #{n}")
+      (n.is_a?(Integer) && (n % 2).zero?) || (raise "expected an even number, found #{n}")
     end
 
     def validators.length_len(root, str)
-      str.is_a?(String) && str.size == root['len'] ||
+      (str.is_a?(String) && str.size == root['len']) ||
         (raise "expected a string of length #{root['len']}, found #{str.inspect}")
     end
 
@@ -162,7 +162,7 @@ RSpec.describe Validator do
   it 'should allow validations on all keys of an object' do
     validators = Object.new
     def validators.short_string(_, str)
-      str.is_a?(String) && str.length < 5 || (raise "expected a short key, found #{str.inspect}")
+      (str.is_a?(String) && str.length < 5) || (raise "expected a short key, found #{str.inspect}")
     end
 
     schema = { 'obj' => { '$all_keys' => '$short_string', '$all' => 'String' } }
@@ -217,7 +217,7 @@ RSpec.describe Validator do
   it 'should be able to use complex schemas in their full form' do
     validators = Object.new
     def validators.short_string(_, str)
-      str.is_a?(String) && str.length < 5 || (raise "expected a short string, found #{str.inspect}")
+      (str.is_a?(String) && str.length < 5) || (raise "expected a short string, found #{str.inspect}")
     end
 
     schema = {


### PR DESCRIPTION
This [was failing in ruby 3.1](https://github.com/velocidi/frise/runs/5674399835?check_suite_focus=true#step:5:18) because of https://github.com/ruby/psych/issues/533.

The changes are similar to the fix here: https://github.com/iknow/loadable_config/pull/12.