### PR TITLE
Revert $delete improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,7 @@
 - Breaking changes
   - Increase minimum required ruby version to 2.6.0 ([#22](https://github.com/velocidi/frise/pull/22)).
 - Bug fixes
-  - Fix `$delete` directive behavior, allowing it to work across any number of configuration tree levels 
-    ([#24](https://github.com/velocidi/frise/pull/24)).
-  - Fix symbol table when processing included files ([#25](https://github.com/velocidi/frise/pull/25)).
-  - Fix YAML.safe_load call arguments error in ruby 3.1 ([#25](https://github.com/velocidi/frise/pull/26)).
+  - Fix YAML.safe_load call arguments error in ruby 3.1 ([#26](https://github.com/velocidi/frise/pull/26)).
 
 ### 0.4.1 (July 7, 2020)
 

--- a/lib/frise/defaults_loader.rb
+++ b/lib/frise/defaults_loader.rb
@@ -38,7 +38,7 @@ module Frise
           merge_defaults_obj({}, defaults)
         end
 
-      elsif config == @delete_sym || defaults == @delete_sym
+      elsif config == @delete_sym
         config
 
       elsif defaults_class == 'Array' && config_class == 'Array'

--- a/lib/frise/loader.rb
+++ b/lib/frise/loader.rb
@@ -67,21 +67,18 @@ module Frise
 
       # process $include directives
       config, next_include_confs = extract_include(config, at_path)
-      include_confs = next_include_confs.map { |include| { _this: config, include: include } } + include_confs_stack
+      include_confs = next_include_confs + include_confs_stack
       res = if include_confs.empty?
               config.to_h { |k, v| [k, process_includes(v, at_path + [k], root_config, global_vars)] }
             else
               Lazy.new do
                 include_conf = include_confs.first
                 rest_include_confs = include_confs[1..]
-                symbol_table = build_symbol_table(root_config, at_path, include_conf[:_this], global_vars,
-                                                  include_conf[:include])
-                included_config = Parser.parse(include_conf[:include]['file'], symbol_table)
-                processed_included_config = process_includes(included_config, at_path,
-                                                             merge_at(root_config, at_path, included_config),
-                                                             global_vars, rest_include_confs)
-                config = @defaults_loader.merge_defaults_obj(config, processed_included_config)
-                process_includes(config, at_path, merge_at(root_config, at_path, config), global_vars)
+                symbol_table = build_symbol_table(root_config, at_path, config, global_vars, include_conf)
+                included_config = Parser.parse(include_conf['file'], symbol_table)
+                config = @defaults_loader.merge_defaults_obj(config, included_config)
+                process_includes(config, at_path, merge_at(root_config, at_path, config), global_vars,
+                                 rest_include_confs)
               end
             end
       @delete_sym.nil? ? res : omit_deleted(res)

--- a/spec/fixtures/_defaults/loader_test13.yml
+++ b/spec/fixtures/_defaults/loader_test13.yml
@@ -1,6 +1,0 @@
-bar: "str3"
-baz: "str4"
-other: "str5"
-kept_from_default: "str"
-my_array:
-  - "incorrect"

--- a/spec/fixtures/loader_test13.yml
+++ b/spec/fixtures/loader_test13.yml
@@ -1,8 +1,0 @@
-$include:
-  - "{{ _file_dir }}/loader_test13_include.yml"
-
-foo: $delete
-bar: "str"
-other: $delete
-my_array:
-  - "correct"

--- a/spec/fixtures/loader_test13.yml
+++ b/spec/fixtures/loader_test13.yml
@@ -1,0 +1,9 @@
+$include:
+  - "{{ _file_dir }}/loader_test13_include_part1.yml"
+
+foo:
+  a:
+    bar: 1
+  b:
+    bar: 2
+    default: "override"

--- a/spec/fixtures/loader_test13_include.yml
+++ b/spec/fixtures/loader_test13_include.yml
@@ -1,8 +1,0 @@
-$include:
-  - "{{ _file_dir }}/_defaults/loader_test13.yml"
-
-foo: "str2"
-bar: $delete
-baz: $delete
-liquid: {% if foo %}true{% endif %}
-my_array: $delete

--- a/spec/fixtures/loader_test13_include_a.yml
+++ b/spec/fixtures/loader_test13_include_a.yml
@@ -1,0 +1,1 @@
+baz: "specific_to_a"

--- a/spec/fixtures/loader_test13_include_part1.yml
+++ b/spec/fixtures/loader_test13_include_part1.yml
@@ -1,0 +1,6 @@
+$include:
+  - "{{ _file_dir }}/loader_test13_include_part2.yml"
+
+foo:
+  c:
+    bar: 3

--- a/spec/fixtures/loader_test13_include_part2.yml
+++ b/spec/fixtures/loader_test13_include_part2.yml
@@ -1,0 +1,9 @@
+foo:
+  {% for _foo in foo %}
+  {{ _foo[0] }}:
+    $include:
+      - file: '{{ _file_dir }}/loader_test13_include_{{ _foo[0] }}.yml'
+        constants: { _this_id: '{{ _foo[0] }}' }
+      - file: '{{ _file_dir }}/loader_test13_include_part3.yml'
+        constants: { _this_id: '{{ _foo[0] }}' }
+  {% endfor %}

--- a/spec/fixtures/loader_test13_include_part3.yml
+++ b/spec/fixtures/loader_test13_include_part3.yml
@@ -1,0 +1,2 @@
+id: {{ _this_id }}
+default: "default"

--- a/spec/fixtures/loader_test14_1.yml
+++ b/spec/fixtures/loader_test14_1.yml
@@ -1,4 +1,0 @@
-$include:
-  - "{{ _file_dir }}/loader_test14_include_part1.yml"
-  - "{{ _file_dir }}/loader_test14_include_part2.yml"
-  - "{{ _file_dir }}/loader_test14_include_part3.yml"

--- a/spec/fixtures/loader_test14_2.yml
+++ b/spec/fixtures/loader_test14_2.yml
@@ -1,4 +1,0 @@
-$include:
-  - "{{ _file_dir }}/loader_test14_include_part3.yml"
-  - "{{ _file_dir }}/loader_test14_include_part2.yml"
-  - "{{ _file_dir }}/loader_test14_include_part1.yml"

--- a/spec/fixtures/loader_test14_include_part1.yml
+++ b/spec/fixtures/loader_test14_include_part1.yml
@@ -1,8 +1,0 @@
-my_obj:
-  obj1:
-    key11: 'key11'
-    key12: 'key12'
-  obj2:
-    key21: 'key21'
-    key22: 'key22'
-  obj3: $delete

--- a/spec/fixtures/loader_test14_include_part2.yml
+++ b/spec/fixtures/loader_test14_include_part2.yml
@@ -1,6 +1,0 @@
-my_obj:
-  obj1:
-    key13: 'key13'
-  obj2: $delete
-  obj3:
-    key31: 'key31'

--- a/spec/fixtures/loader_test14_include_part3.yml
+++ b/spec/fixtures/loader_test14_include_part3.yml
@@ -1,6 +1,0 @@
-my_obj:
-  obj1: $delete
-  obj2:
-    key23: 'key23'
-  obj3:
-    key32: 'key32'

--- a/spec/frise/loader_spec.rb
+++ b/spec/frise/loader_spec.rb
@@ -265,31 +265,4 @@ RSpec.describe Loader do
       " - At variable1.value2: missing required value\n"
     ).to_stdout.and raise_error(SystemExit)
   end
-
-  it 'should delete sub-tree when value is $delete' do
-    loader = Loader.new(exit_on_fail: false)
-
-    conf = loader.load(fixture_path('loader_test13.yml'))
-    expect(conf).to eq(
-      'bar' => 'str',
-      'kept_from_default' => 'str',
-      'my_array' => ['correct']
-    )
-  end
-
-  it 'should provide consistent $delete results according to inclusion order' do
-    loader = Loader.new(exit_on_fail: false)
-
-    conf = loader.load(fixture_path('loader_test14_1.yml'))
-    expect(conf).to eq({ 'my_obj' => {
-                         'obj1' => { 'key11' => 'key11', 'key12' => 'key12', 'key13' => 'key13' },
-                         'obj2' => { 'key21' => 'key21', 'key22' => 'key22' }
-                       } })
-
-    conf = loader.load(fixture_path('loader_test14_2.yml'))
-    expect(conf).to eq({ 'my_obj' => {
-                         'obj2' => { 'key23' => 'key23' },
-                         'obj3' => { 'key31' => 'key31', 'key32' => 'key32' }
-                       } })
-  end
 end

--- a/spec/frise/loader_spec.rb
+++ b/spec/frise/loader_spec.rb
@@ -265,4 +265,17 @@ RSpec.describe Loader do
       " - At variable1.value2: missing required value\n"
     ).to_stdout.and raise_error(SystemExit)
   end
+
+  it 'should process complex nested includes with templating' do
+    loader = Loader.new(exit_on_fail: false)
+
+    conf = loader.load(fixture_path('loader_test13.yml'))
+    expect(conf).to eq(
+      'foo' => {
+        'a' => { 'bar' => 1, 'default' => 'default', 'id' => 'a', 'baz' => 'specific_to_a' },
+        'b' => { 'bar' => 2, 'default' => 'override', 'id' => 'b' },
+        'c' => { 'bar' => 3, 'default' => 'default', 'id' => 'c' }
+      }
+    )
+  end
 end


### PR DESCRIPTION
PRs #23, #24, and #25 modified the $delete behaviour but introduced some bugs.

This code was never published in over a year. I think it's best to remove these changes for now and re-introduce this again once it's a priority again and we fix it. This will allow for this codebase to evolve without the requirement of fixing these bugs beforehand.

I added a minimal regression test that fails without this revert.