### PR TITLE
Make liquid parsing/rending strict and update liquid version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 0.6.0 (TBD)
+
+- Breaking changes
+  - Liquid parsing is now strict ([#29](https://github.com/velocidi/frise/pull/29)).
+  - Update liquid gem to `5.3.0` ([#29](https://github.com/velocidi/frise/pull/29)).
+
 ### 0.5.1 (March 28, 2022)
 
 - Breaking changes

--- a/frise.gemspec
+++ b/frise.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.6.0'
 
-  spec.add_dependency 'liquid', '~> 4.0'
+  spec.add_dependency 'liquid', '~> 5.3.0'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 13.0'

--- a/lib/frise/parser.rb
+++ b/lib/frise/parser.rb
@@ -16,7 +16,12 @@ module Frise
       def parse_as_text(file, symbol_table = nil)
         return nil unless File.file? file
         content = File.read(file)
-        content = Liquid::Template.parse(content).render with_internal_vars(file, symbol_table) if symbol_table
+        template = Liquid::Template.parse(content, error_mode: :strict)
+        if symbol_table
+          content = template.render!(with_internal_vars(file, symbol_table), {
+                                       strict_filters: true
+                                     })
+        end
         content
       end
 

--- a/lib/frise/version.rb
+++ b/lib/frise/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Frise
-  VERSION = '0.5.2.pre'
+  VERSION = '0.6.0.pre'
 end

--- a/spec/fixtures/invalid_liquid_1.yml
+++ b/spec/fixtures/invalid_liquid_1.yml
@@ -1,0 +1,1 @@
+a: {{ var2 && var3 }} # should be a "AND"

--- a/spec/fixtures/invalid_liquid_2.yml
+++ b/spec/fixtures/invalid_liquid_2.yml
@@ -1,0 +1,1 @@
+a: {{ var1 | invalid_filter }} # invalid_filter does not exist

--- a/spec/frise/parser_spec.rb
+++ b/spec/frise/parser_spec.rb
@@ -10,6 +10,15 @@ RSpec.describe Parser do
     expect(conf).to eq('str' => 'abc', 'int' => 4, 'bool' => true)
   end
 
+  it 'should raise an exception if parsing invalid liquid template' do
+    expect { Parser.parse(fixture_path('invalid_liquid_1.yml'), { a: 1 }) }.to raise_exception(Liquid::SyntaxError)
+    expect { Parser.parse(fixture_path('invalid_liquid_2.yml'), { a: 1 }) }.to raise_exception(Liquid::UndefinedFilter)
+
+    # FIXME: If the symbol_table is empty we don't render the template.
+    #        Not sure if we want this behaviour in the long run
+    expect { Parser.parse(fixture_path('invalid_liquid_2.yml')) }.not_to raise_exception
+  end
+
   it 'parse a file as a Liquid template if a symbol table is passed' do
     conf1 = Parser.parse(fixture_path('simple_liquid.yml'), 'var1' => 'REPLACED', 'var2' => 1)
     expect(conf1).to eq('str' => 'replaced', 'int' => 1, 'bool' => true)


### PR DESCRIPTION
Updates the liquid gem version to the latest and makes liquid parsing strict. 

I think this behavior is helpful and should be the default. However, I wonder if we should allow relaxed parsing via configuration? Do you think it is worth it?